### PR TITLE
Remove space inside aria-describedby attribute

### DIFF
--- a/jquery-accessible-simple-tooltip-aria.js
+++ b/jquery-accessible-simple-tooltip-aria.js
@@ -20,7 +20,7 @@
         var aria_describedby = element.attr('aria-describedby') || '';
 
         element.attr({
-            'aria-describedby': 'label_simpletooltip_' + index_lisible + ' ' + aria_describedby
+            'aria-describedby': ('label_simpletooltip_' + index_lisible + ' ' + aria_describedby).trim()
         });
 
         element.wrap('<span class="' + prefix_class + 'simpletooltip_container"></span>');


### PR DESCRIPTION
Trim space inside aria-describedby attribute as it triggers error on Wave tool in case of empty aria_describedby. (ex: aria-describedby="label_simpletooltip_rlao2ir12o " => aria-describedby="label_simpletooltip_rlao2ir12o")